### PR TITLE
Fixed the auto-numbering issues on guide pages

### DIFF
--- a/_merchants/Merchants' Guide/Bagaimana untuk menggunakan RedeemSG Merchant.md
+++ b/_merchants/Merchants' Guide/Bagaimana untuk menggunakan RedeemSG Merchant.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-1. Muat turun RedeemSG Merchant dan log mengguanakan nomber telefon bimbit anda. 
+<p>1. Muat turun RedeemSG Merchant dan log mengguanakan nomber telefon bimbit anda. </p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -32,18 +32,18 @@ a.bp-button {
 </table>
 
 
-2. Masukkan kod kedai yang disediakan oleh rakan sekerja atau Duta anda.
+<p>2. Masukkan kod kedai yang disediakan oleh rakan sekerja atau Duta anda.</p>
 
 <p><img src="/images/merchants/merchants-infographics/malay/10%20Shop%20code%20.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
-3. Mulakan dengan mengimbas baucar. 
+<p>3. Mulakan dengan mengimbas baucar. </p>
 <p><img src="/images/merchants/merchants-infographics/malay/2%20Home%20scan%20with%20pic%20no%20logo.png" style="width:300px !important;" alt="Scan voucher screen"/> </p>
 
-4. Untuk menambah anggota kakitangan yang lain, tunjukkan kod kedai kepada mereka.
+<p>4. Untuk menambah anggota kakitangan yang lain, tunjukkan kod kedai kepada mereka.</p>
  
 <p><img src="/images/merchants/merchants-infographics/malay/2%20Show%20shop%20code.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
-5. Ketik "Transaksi" untuk melihat baucar yang telah anda imbas. Ketik "Pembayaran" untuk melihat pembayaran ke akaun bank anda.
+<p>5. Ketik "Transaksi" untuk melihat baucar yang telah anda imbas. Ketik "Pembayaran" untuk melihat pembayaran ke akaun bank anda.</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/Bagaimana untuk menggunakan RedeemSG Merchant.md
+++ b/_merchants/Merchants' Guide/Bagaimana untuk menggunakan RedeemSG Merchant.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-<p>1. Muat turun RedeemSG Merchant dan log mengguanakan nomber telefon bimbit anda. </p>
+<p>1: Muat turun RedeemSG Merchant dan log mengguanakan nomber telefon bimbit anda. </p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -32,18 +32,18 @@ a.bp-button {
 </table>
 
 
-<p>2. Masukkan kod kedai yang disediakan oleh rakan sekerja atau Duta anda.</p>
+<p>2: Masukkan kod kedai yang disediakan oleh rakan sekerja atau Duta anda.</p>
 
 <p><img src="/images/merchants/merchants-infographics/malay/10%20Shop%20code%20.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
-<p>3. Mulakan dengan mengimbas baucar. </p>
+<p>3: Mulakan dengan mengimbas baucar. </p>
 <p><img src="/images/merchants/merchants-infographics/malay/2%20Home%20scan%20with%20pic%20no%20logo.png" style="width:300px !important;" alt="Scan voucher screen"/> </p>
 
-<p>4. Untuk menambah anggota kakitangan yang lain, tunjukkan kod kedai kepada mereka.</p>
+<p>4: Untuk menambah anggota kakitangan yang lain, tunjukkan kod kedai kepada mereka.</p>
  
 <p><img src="/images/merchants/merchants-infographics/malay/2%20Show%20shop%20code.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
-<p>5. Ketik "Transaksi" untuk melihat baucar yang telah anda imbas. Ketik "Pembayaran" untuk melihat pembayaran ke akaun bank anda.</p>
+<p>5: Ketik "Transaksi" untuk melihat baucar yang telah anda imbas. Ketik "Pembayaran" untuk melihat pembayaran ke akaun bank anda.</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/Onboard RedeemSG Merchant App.md
+++ b/_merchants/Merchants' Guide/Onboard RedeemSG Merchant App.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-<p>1. Download RedeemSG Merchant mobile app and log in with your mobile number. </p>
+<p>1: Download RedeemSG Merchant mobile app and log in with your mobile number. </p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -32,17 +32,17 @@ a.bp-button {
 </table>
 
 
-<p>2. Key in the shop code provided by your co-worker or the Ambassador. </p>
+<p>2: Key in the shop code provided by your co-worker or the Ambassador. </p>
 
 <p><img src="/images/merchants/merchants-infographics/english/10%20Shop%20code.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
-<p>3. Start scanning vouchers. </p>
+<p>3: Start scanning vouchers. </p>
 <p><img src="/images/merchants/merchants-infographics/english/2%20Home%20scan%20with%20pic%20.png" style="width:300px !important;" alt="Scan voucher screen"/> </p>
 
-<p>4. To add other staff members, show them the shop code. </p>
+<p>4: To add other staff members, show them the shop code. </p>
 <p><img src="/images/merchants/merchants-infographics/english/3%20Eter%20shop%20code.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
-<p>5. Type "Transactions" to see vouchers you've scanned. Tap "Payouts" to see payments to your bank account.</p>
+<p>5: Type "Transactions" to see vouchers you've scanned. Tap "Payouts" to see payments to your bank account.</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/Onboard RedeemSG Merchant App.md
+++ b/_merchants/Merchants' Guide/Onboard RedeemSG Merchant App.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-1: Download RedeemSG Merchant mobile app and log in with your mobile number. 
+<p>1. Download RedeemSG Merchant mobile app and log in with your mobile number. </p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -32,17 +32,17 @@ a.bp-button {
 </table>
 
 
-2: Key in the shop code provided by your co-worker or the Ambassador. 
+<p>2. Key in the shop code provided by your co-worker or the Ambassador. </p>
 
 <p><img src="/images/merchants/merchants-infographics/english/10%20Shop%20code.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
-3: Start scanning vouchers. 
+<p>3. Start scanning vouchers. </p>
 <p><img src="/images/merchants/merchants-infographics/english/2%20Home%20scan%20with%20pic%20.png" style="width:300px !important;" alt="Scan voucher screen"/> </p>
 
-4: To add other staff members, show them the shop code. 
+<p>4. To add other staff members, show them the shop code. </p>
 <p><img src="/images/merchants/merchants-infographics/english/3%20Eter%20shop%20code.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
-5: Type "Transactions" to see vouchers you've scanned. Tap "Payouts" to see payments to your bank account.
+<p>5. Type "Transactions" to see vouchers you've scanned. Tap "Payouts" to see payments to your bank account.</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/RedeemSG Merchant செயலியில் பதிவு செய்யுங்கள்.md
+++ b/_merchants/Merchants' Guide/RedeemSG Merchant செயலியில் பதிவு செய்யுங்கள்.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-<p>1. RedeemSG Merchant செயலியைப் பதிவிறக்கம் செய்து, உங்கள் கைப்பேசி எண்ணுடன் உட்பதிவு செய்யுங்கள்.</p>
+<p>1: RedeemSG Merchant செயலியைப் பதிவிறக்கம் செய்து, உங்கள் கைப்பேசி எண்ணுடன் உட்பதிவு செய்யுங்கள்.</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -32,21 +32,21 @@ a.bp-button {
 </table>
 
 
-<p>2. உங்களது சக ஊழியர் அல்லது தூதர் வழங்கிய கடை குறியீட்டை உள்ளிடுங்கள். </p>
+<p>2: உங்களது சக ஊழியர் அல்லது தூதர் வழங்கிய கடை குறியீட்டை உள்ளிடுங்கள். </p>
 
 <p><img src="/images/merchants/merchants-infographics/tamil/10%20Shop%20c.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
 
-<p>3. பற்றுச்சீட்டுகளை ஸ்கேன் செய்யத் தொடங்குங்கள். </p>
+<p>3: பற்றுச்சீட்டுகளை ஸ்கேன் செய்யத் தொடங்குங்கள். </p>
 <p><img src="/images/merchants/merchants-infographics/tamil/1%20Home%20start%20.png" style="width:300px !important;" alt="Scan voucher screen"/> </p>
 
 
-<p>4. மற்ற ஊழியர்களைச் சேர்க்க, கடை குறியீட்டை அவர்களிடம் காட்டுங்கள். </p>
+<p>4: மற்ற ஊழியர்களைச் சேர்க்க, கடை குறியீட்டை அவர்களிடம் காட்டுங்கள். </p>
  
 <p><img src="/images/merchants/merchants-infographics/tamil/2%20Show%20shop%20code.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
 
-<p>5. நீங்கள் ஸ்கேன் செய்த பற்றுச்சீட்டுகளைப் பார்வையிட, “பரிவர்த்தனைகள்” மீது தட்டுங்கள். உங்கள் வங்கிக் கணக்கில் சேர்க்கப்பட்ட தொகையைப் பார்வையிட, “தொகை வழங்கீடுகள்” மீது தட்டுங்கள். </p>
+<p>5: நீங்கள் ஸ்கேன் செய்த பற்றுச்சீட்டுகளைப் பார்வையிட, “பரிவர்த்தனைகள்” மீது தட்டுங்கள். உங்கள் வங்கிக் கணக்கில் சேர்க்கப்பட்ட தொகையைப் பார்வையிட, “தொகை வழங்கீடுகள்” மீது தட்டுங்கள். </p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/RedeemSG Merchant செயலியில் பதிவு செய்யுங்கள்.md
+++ b/_merchants/Merchants' Guide/RedeemSG Merchant செயலியில் பதிவு செய்யுங்கள்.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-1. RedeemSG Merchant செயலியைப் பதிவிறக்கம் செய்து, உங்கள் கைப்பேசி எண்ணுடன் உட்பதிவு செய்யுங்கள்.
+<p>1. RedeemSG Merchant செயலியைப் பதிவிறக்கம் செய்து, உங்கள் கைப்பேசி எண்ணுடன் உட்பதிவு செய்யுங்கள்.</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -32,21 +32,21 @@ a.bp-button {
 </table>
 
 
-2. உங்களது சக ஊழியர் அல்லது தூதர் வழங்கிய கடை குறியீட்டை உள்ளிடுங்கள். 
+<p>2. உங்களது சக ஊழியர் அல்லது தூதர் வழங்கிய கடை குறியீட்டை உள்ளிடுங்கள். </p>
 
 <p><img src="/images/merchants/merchants-infographics/tamil/10%20Shop%20c.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
 
-3. பற்றுச்சீட்டுகளை ஸ்கேன் செய்யத் தொடங்குங்கள். 
+<p>3. பற்றுச்சீட்டுகளை ஸ்கேன் செய்யத் தொடங்குங்கள். </p>
 <p><img src="/images/merchants/merchants-infographics/tamil/1%20Home%20start%20.png" style="width:300px !important;" alt="Scan voucher screen"/> </p>
 
 
-4. மற்ற ஊழியர்களைச் சேர்க்க, கடை குறியீட்டை அவர்களிடம் காட்டுங்கள். 
+<p>4. மற்ற ஊழியர்களைச் சேர்க்க, கடை குறியீட்டை அவர்களிடம் காட்டுங்கள். </p>
  
 <p><img src="/images/merchants/merchants-infographics/tamil/2%20Show%20shop%20code.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
 
-5. நீங்கள் ஸ்கேன் செய்த பற்றுச்சீட்டுகளைப் பார்வையிட, “பரிவர்த்தனைகள்” மீது தட்டுங்கள். உங்கள் வங்கிக் கணக்கில் சேர்க்கப்பட்ட தொகையைப் பார்வையிட, “தொகை வழங்கீடுகள்” மீது தட்டுங்கள். 
+<p>5. நீங்கள் ஸ்கேன் செய்த பற்றுச்சீட்டுகளைப் பார்வையிட, “பரிவர்த்தனைகள்” மீது தட்டுங்கள். உங்கள் வங்கிக் கணக்கில் சேர்க்கப்பட்ட தொகையைப் பார்வையிட, “தொகை வழங்கீடுகள்” மீது தட்டுங்கள். </p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/加入 RedeemSG Merchant 手机应用程序.md
+++ b/_merchants/Merchants' Guide/加入 RedeemSG Merchant 手机应用程序.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-<p>1. 下载 RedeemSG Merchant 手机应用程序, 以您的手机号码登入。</p>
+<p>1: 下载 RedeemSG Merchant 手机应用程序, 以您的手机号码登入。</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -31,20 +31,20 @@ a.bp-button {
 </tbody>
 </table>
 
-<p>2. 输入社理会大使或手机简讯所提供的商店代码。</p>
+<p>2: 输入社理会大使或手机简讯所提供的商店代码。</p>
 
 <p><img src="/images/merchants/merchants-infographics/chinese/10%20Shop%20code%20NEW.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
-<p>3. 您便可开始扫描购物券。</p>
+<p>3: 您便可开始扫描购物券。</p>
 
 <p><img src="/images/merchants/merchants-infographics/chinese/2%20Home%20scan%20with%20pic%20.png" style="width:210px !important;" alt="Scan voucher screen"/> </p>
 
 
-<p>4. 若想添加其他管理员或店员，您只需分享商店代码即可。</p>
+<p>4: 若想添加其他管理员或店员，您只需分享商店代码即可。</p>
 
 <p><img src="/images/merchants/merchants-infographics/chinese/2%20Settings%20shop%20show%20codeNEW.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
-<p>5. 点击“交易”，查看已扫描的购物券金额。点击“收款”，查看已转入您银行户口的款项。</p>
+<p>5: 点击“交易”，查看已扫描的购物券金额。点击“收款”，查看已转入您银行户口的款项。</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>

--- a/_merchants/Merchants' Guide/加入 RedeemSG Merchant 手机应用程序.md
+++ b/_merchants/Merchants' Guide/加入 RedeemSG Merchant 手机应用程序.md
@@ -14,7 +14,7 @@ a.bp-button {
 }
 </style>
 
-1. <p>下载 RedeemSG Merchant 手机应用程序, 以您的手机号码登入。</p>
+<p>1. 下载 RedeemSG Merchant 手机应用程序, 以您的手机号码登入。</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>
@@ -31,20 +31,20 @@ a.bp-button {
 </tbody>
 </table>
 
-2. <p>输入社理会大使或手机简讯所提供的商店代码。</p>
+<p>2. 输入社理会大使或手机简讯所提供的商店代码。</p>
 
 <p><img src="/images/merchants/merchants-infographics/chinese/10%20Shop%20code%20NEW.png" style="width:300px !important;" alt="Enter shop code screen"/> </p>
 
-3. <p>您便可开始扫描购物券。</p>
+<p>3. 您便可开始扫描购物券。</p>
 
 <p><img src="/images/merchants/merchants-infographics/chinese/2%20Home%20scan%20with%20pic%20.png" style="width:210px !important;" alt="Scan voucher screen"/> </p>
 
 
-4. <p>若想添加其他管理员或店员，您只需分享商店代码即可。</p>
+<p>4. 若想添加其他管理员或店员，您只需分享商店代码即可。</p>
 
 <p><img src="/images/merchants/merchants-infographics/chinese/2%20Settings%20shop%20show%20codeNEW.png" style="width:300px !important;" alt="Shop code screen"/> </p>
 
-5. <p>点击“交易”，查看已扫描的购物券金额。点击“收款”，查看已转入您银行户口的款项。</p>
+<p>5. 点击“交易”，查看已扫描的购物券金额。点击“收款”，查看已转入您银行户口的款项。</p>
 
 <table border="0" cellspacing="0" cellpadding="0">
 <tbody>


### PR DESCRIPTION
The auto-numbering of using "1." and "2." not working and all numberings were resetting to "1."